### PR TITLE
If using other node then "Custom Node" 

### DIFF
--- a/packages/apps/src/NavBar/MainNav/SettingNode.tsx
+++ b/packages/apps/src/NavBar/MainNav/SettingNode.tsx
@@ -19,7 +19,7 @@ function SettingNode() {
     }else if(apiUrl === 'wss://mainnet.chainx.org/ws'){
       setNetInfo(t('Overseas Node'))
     }else{
-      setNetInfo(t('Test Node'))
+      setNetInfo(t('Custom Node'))
     }
   }, [apiUrl])
 

--- a/packages/apps/src/NavBar/SideBars/index.tsx
+++ b/packages/apps/src/NavBar/SideBars/index.tsx
@@ -136,7 +136,7 @@ function Sidebars ({ className = '', onClose, isCollapsed }: Props): React.React
     }else if(apiUrl === 'wss://mainnet.chainx.org/ws'){
       setNetInfo(t('Overseas Node'))
     }else{
-      setNetInfo(t('Test Node'))
+      setNetInfo(t('Custom Node'))
     }
   }, [apiUrl])
 


### PR DESCRIPTION
"Test Node" **tricks** people to believe they are in _testnet_, when they are actually using a custom node, can be mainnet or testnet
 (example, using patract node= mainnet node, not testnet)